### PR TITLE
docs: remove parâmetro da instrução de instalação

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ O **PO UI** possui o seu próprio tema, mas disponibilizamos um tema com os padr
 Para utilizá-lo, instale o pacote `@totvs/po-theme` conforme abaixo:
 
 ```
-npm i --save @totvs/po-theme
+npm i @totvs/po-theme
 ```
 
 Em seguida, atualize o arquivo `angular.json` para utilizar o tema.


### PR DESCRIPTION
# Descrição

Nas instruções de instalação do pacote, o parâmetro `--save` pode ser removido, já que o pacote é automaticamente inserido em `dependecies` desde a versão 5 do NPM.