### PR TITLE
feat(button): corrige espaçamento do `PoButton`

### DIFF
--- a/src/po-theme-custom.css
+++ b/src/po-theme-custom.css
@@ -401,7 +401,7 @@ po-button {
   --line-height: var(--line-height-none);
   --border-radius: var(--border-radius-md);
   --border-width: var(--border-width-md);
-  --padding: 0 0.5rem;
+  --padding: 0 1em;
 
   /* danger */
   --text-color-danger: var(--color-neutral-light-00);


### PR DESCRIPTION
**BUTTON**

Altera a unidade de medida do padding do botão.

De: rem
```
--padding: 0 1rem;
```
Para: em
```
--padding: 0 1em;
```

Fixes DTHFUI-6022, DTHFUI-6353