### PR TITLE
fix(menu): ajusta background do campo pesquisa

### DIFF
--- a/src/po-theme-custom.css
+++ b/src/po-theme-custom.css
@@ -948,7 +948,7 @@ po-menu-filter {
   --text-color-placeholder: var(--color-neutral-light-30);
   --color: var(--color-neutral);
   --border-radius: var(--border-radius-md);
-  --background: var(--color-neutral-light-05);
+  --background: var(--color-neutral-light-00);
 
   --text-color: var(--color-neutral-dark-90);
 


### PR DESCRIPTION
Ajusta a cor do background do campo pesquisa do menu.

[app.component.zip](https://github.com/totvs/po-theme-totvs/files/13443935/app.component.zip)
[styles.zip](https://github.com/totvs/po-theme-totvs/files/13443938/styles.zip)
