### PR TITLE
feat(tabs): adiciona o token --background-item-default

### DIFF
--- a/src/po-theme-custom.css
+++ b/src/po-theme-custom.css
@@ -1444,6 +1444,8 @@ po-tab-button {
   --color: var(--color-action-default);
   --border-radius: var(--border-radius-md);
 
+  --background-item-default: var(--color-transparent);
+
   --background-item-selected: var(--color-neutral-light-00);
 
   --color-hover: var(--color-brand-01-darkest);


### PR DESCRIPTION
O componente po-tabs implementa apenas o token --background, que altera a cor de fundo do componente por inteiro. Adiciona o token --background-item-default para permitir a customização da cor de fundo do item padrão separadamente da cor de fundo de todo o po-tabs.

Fixes: DTHFUI-10947