### PR TITLE
refactor(navbar): marca componente po-navbar como depreciado

### DIFF
--- a/src/po-theme-custom.css
+++ b/src/po-theme-custom.css
@@ -1132,30 +1132,30 @@ po-page-content {
   NAVBAR
 \*------------------------------------*/
 
-  --color-navbar-color: var(--color-neutral-light-00);
+  --color-navbar-color: var(--color-neutral-light-00); /*Deprecated v23.x.x */
 
   /*------------------------------------*\
   NAVBAR ACTION
 \*------------------------------------*/
-  --color-navbar-action-color-content: var(--color-action-default);
+  --color-navbar-action-color-content: var(--color-action-default); /*Deprecated v23.x.x */
 
   /*------------------------------------*\
   NAVBAR ACTION POPUP
 \*------------------------------------*/
-  --color-navbar-action-popup-color-content: var(--color-navbar-action-color-content);
+  --color-navbar-action-popup-color-content: var(--color-navbar-action-color-content); /*Deprecated v23.x.x */
 
   /*------------------------------------*\
   NAVBAR ITEM
 \*------------------------------------*/
-  --color-navbar-item-color: var(--color-action-default);
-  --color-navbar-item-color-selected: var(--color-neutral);
-  --color-navbar-item-color-shadow-selected: var(--color-action-default);
+  --color-navbar-item-color: var(--color-action-default); /*Deprecated v23.x.x */
+  --color-navbar-item-color-selected: var(--color-neutral); /*Deprecated v23.x.x */
+  --color-navbar-item-color-shadow-selected: var(--color-action-default); /*Deprecated v23.x.x */
 
   /*------------------------------------*\
   NAVBAR ITEM NAVIGATION
 \*------------------------------------*/
-  --color-navbar-item-navigation-color-icon: var(--color-action-default);
-  --color-navbar-item-navigation-color-icon-disabled: var(--color-neutral-light-20);
+  --color-navbar-item-navigation-color-icon: var(--color-action-default); /*Deprecated v23.x.x */
+  --color-navbar-item-navigation-color-icon-disabled: var(--color-neutral-light-20); /*Deprecated v23.x.x */
 }
 
 /*------------------------------------*\


### PR DESCRIPTION
Marca o componente po-navbar como @deprecated,
indicando que ele será removido em versões futuras. A recomendação é utilizar o po-header.

fixes DTHFUI-11848

BREAKING CHANGE: marca componente po-navbar como @deprecated

O componente po-navbar não será mais mantido e
será removido em versões futuras.
A alternativa recomendada é utilizar o po-header.